### PR TITLE
feat: Use type import

### DIFF
--- a/src/RedisStore.ts
+++ b/src/RedisStore.ts
@@ -1,5 +1,6 @@
+
+import { EventEmitter } from 'events';
 import type { SessionData, SessionStore } from '@mgcrea/fastify-session';
-import type { EventEmitter } from 'events';
 import type { Redis } from 'ioredis';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/src/RedisStore.ts
+++ b/src/RedisStore.ts
@@ -1,6 +1,6 @@
-import { SessionData, SessionStore } from '@mgcrea/fastify-session';
-import { EventEmitter } from 'events';
-import { Redis } from 'ioredis';
+import type { SessionData, SessionStore } from '@mgcrea/fastify-session';
+import type { EventEmitter } from 'events';
+import type { Redis } from 'ioredis';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 type StoredData = { data: string; expiry: number | null }; // [session data, expiry time in ms]


### PR DESCRIPTION
Just a minor fix using the Type import : https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html#type-only-imports-and-export

I was a bit confused reading the import of `ioredis` in the code as we supply the redis client in the `RedisStore` constructor.

Nice lib btw